### PR TITLE
Use stdin as input if no file operand with render

### DIFF
--- a/oyster
+++ b/oyster
@@ -63,7 +63,15 @@ NL="
 #   1 If the rendering failed.
 render()
 {
-    _eval_embedded_shell "$1" > /tmp/content.html
+    if [ -n "$1" ]
+    then
+        _eval_embedded_shell < "$1" > /tmp/content.html
+    else
+        _eval_embedded_shell <<eof > /tmp/content.html
+$(cat)
+eof
+    fi
+
     _content=$(cat /tmp/content.html)
     while [ -n "$_template" ]
     do
@@ -88,8 +96,6 @@ render()
 # TODO comment
 _eval_embedded_shell()
 {
-    exec_file=$1
-
     while IFS= read -r _line
     do
 
@@ -131,9 +137,8 @@ eof
     # Write a new line as we have reached the end of the original source
     # code line.
     printf "\n"
-    done < $exec_file
+    done
 
-    unset exec_file
     unset mode
     unset code
 }

--- a/test/test_render
+++ b/test/test_render
@@ -34,6 +34,12 @@ test_simple_file()
     diff -u "$TDATA/simple.out.txt" "$TWORK/simple.out.txt"
 }
 
+test_stdin()
+{
+    render < "$TDATA/simple.in.txt" > "$TWORK/simple.out.txt"
+    diff -u "$TDATA/simple.out.txt" "$TWORK/simple.out.txt"
+}
+
 test_whitespace_preservation()
 {
     render "$TDATA/whitespace.in.txt" > "$TWORK/whitespace.out.txt"


### PR DESCRIPTION
The standard input is used as the input file if no file operand is
specified while invoking render.